### PR TITLE
windows compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ Issues = "https://github.com/cloudmesh/cloudmesh-bumpversion/issues"
 Changelog = "https://github.com/cloudmesh/cloudmesh-bumpversion/blob/main/CHANGELOG.md"
 
 [tool.setuptools.packages.find]
-where = ["src/"]
+where = ["src"]
 # include = ["bumpversion", "cloudmesh.bumpversion.*"]
 
 [project.scripts]


### PR DESCRIPTION
when removing forward slash, `pip install -e .` works for windows

however,
```bash
$ bumpversion
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\stapm\ENV3\Scripts\bumpversion.exe\__main__.py", line 4, in <module>
ModuleNotFoundError: No module named 'bumpversion.bumpversion_command'
(ENV3)
```